### PR TITLE
add API_URL as runtime environment variable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules
+.quasar
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,5 @@ RUN npm install
 
 COPY . .
 
-RUN quasar build
-
-WORKDIR /app/dist/spa
-
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["quasar", "serve", "-p", "9000"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+cd /app
+if [ ! -d "/app/dist/spa" ]; then
+    quasar build
+fi
+cd /app/dist/spa
+
+exec "$@"

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -85,7 +85,11 @@ module.exports = configure(function (/* ctx */) {
           },
         ],
       ],
-      env: { API: "http://localhost:8888" },
+      env: {
+        API: process.env.API_URL
+          ? process.env.API_URL
+          : "http://localhost:8888",
+      },
     },
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer


### PR DESCRIPTION
Adds API_URL environment variable to `quasar.config.js`, defaulting to a hardcoded value if the environment variable is empty. Not running `quasar build` if `/app/dist/spa` exists, because that's not persistent and afaik Docker doesn't allow changing existing container's environment variables.

Closes #3